### PR TITLE
Add ChatGPT endpoints for summarization and content correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@
     GET /api/v1/rule?url=http://blah.com/aaa - get rule for url
     GET /api/v1/rules - get all rules, enabled and disabled
 
+    POST /api/v1/summarize {content: "text content"} - summarize main points from the content
+    POST /api/v1/content-correct {url: "http://aa.com/blah", selector: ".content"} - correct content parsing with a new selector
+
 #### testing
 
 on master (dev version) prefix /ureadability should be added

--- a/backend/rest/server.go
+++ b/backend/rest/server.go
@@ -79,6 +79,18 @@ func (s *Server) routes(frontendDir string) chi.Router {
 			protected.Post("/rule", s.saveRule)
 			protected.Delete("/rule/{id}", s.deleteRule)
 		})
+
+		// New secured endpoint for summarizing main points
+		r.Group(func(protected chi.Router) {
+			protected.Use(basicAuth("ureadability", s.Credentials))
+			protected.Post("/v1/summarize", s.summarizeMainPoints)
+		})
+
+		// New secured endpoint for content correction and re-extraction
+		r.Group(func(protected chi.Router) {
+			protected.Use(basicAuth("ureadability", s.Credentials))
+			protected.Post("/v1/content-correct", s.contentParsedWrong)
+		})
 	})
 
 	fs, err := UM.NewFileServer("/", frontendDir, UM.FsOptSPA)
@@ -222,6 +234,16 @@ func (s *Server) deleteRule(w http.ResponseWriter, r *http.Request) {
 func (s *Server) authFake(w http.ResponseWriter, r *http.Request) {
 	t := time.Now()
 	render.JSON(w, r, JSON{"pong": t.Format("20060102150405")})
+}
+
+// summarizeMainPoints handles the summarization of main points from the content.
+func (s *Server) summarizeMainPoints(w http.ResponseWriter, r *http.Request) {
+	// Implementation for summarizing main points using ChatGPT
+}
+
+// contentParsedWrong handles the correction of content parsing using ChatGPT.
+func (s *Server) contentParsedWrong(w http.ResponseWriter, r *http.Request) {
+	// Implementation for correcting content parsing using ChatGPT
 }
 
 func getBid(id string) primitive.ObjectID {


### PR DESCRIPTION
Adds new secured endpoints for content summarization and correction using ChatGPT, and updates documentation accordingly.

- Introduces two new endpoints `/api/v1/summarize` and `/api/v1/content-correct` in `backend/rest/server.go`. These endpoints are designed to handle summarization of main points from the content and correction of content parsing, respectively. Both endpoints are secured with basic authentication.
- Implements placeholder handler functions `summarizeMainPoints` and `contentParsedWrong` for the new endpoints. These functions are prepared to integrate with ChatGPT for processing requests, although the actual integration logic is marked as a placeholder.
- Updates the `README.md` file to document the new endpoints, providing a brief description of their purpose and example usage. This ensures that users are aware of the new functionality and how to access it.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ukeeper/ukeeper-readability?shareId=b50b3a43-5b0a-4266-82f4-a6b316353ef8).