### PR TITLE
Fix top-3 review findings: SSRF, textarea CRLF corruption, image fetch

### DIFF
--- a/extractor/pics.go
+++ b/extractor/pics.go
@@ -1,6 +1,7 @@
 package extractor
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"sort"
@@ -11,21 +12,41 @@ import (
 	log "github.com/go-pkgz/lgr"
 )
 
-func (f *UReadability) extractPics(iselect *goquery.Selection, url string) (mainImage string, allImages []string, ok bool) {
+const (
+	imageFetchTimeout       = 30 * time.Second
+	maxImageBytes           = 10 << 20 // cap when measuring an image, avoids buffering huge files
+	maxConcurrentImageFetch = 8        // limit parallel image probes per page
+)
+
+// imageClient returns a lazily-built HTTP client for image size probes, sharing one client across
+// all fetches and honoring BlockPrivateNetworks to guard against SSRF via image URLs.
+func (f *UReadability) imageClient() *http.Client {
+	f.imgClientOnce.Do(func() {
+		f.imgClient = &http.Client{Timeout: imageFetchTimeout}
+		if f.BlockPrivateNetworks {
+			f.imgClient.Transport = safeTransport(imageFetchTimeout)
+		}
+	})
+	return f.imgClient
+}
+
+func (f *UReadability) extractPics(ctx context.Context, iselect *goquery.Selection, url string) (mainImage string, allImages []string, ok bool) {
 	images := make(map[int]string)
 
 	type imgInfo struct {
 		url  string
 		size int
 	}
-	var resCh = make(chan imgInfo)
+	resCh := make(chan imgInfo)
 	var wg sync.WaitGroup
+	sem := make(chan struct{}, maxConcurrentImageFetch)
 
 	iselect.Each(func(_ int, s *goquery.Selection) {
-		if im, ok := s.Attr("src"); ok {
+		if im, exists := s.Attr("src"); exists {
 			wg.Go(func() {
-				size := f.getImageSize(im)
-				resCh <- imgInfo{url: im, size: size}
+				sem <- struct{}{}
+				defer func() { <-sem }()
+				resCh <- imgInfo{url: im, size: f.getImageSize(ctx, im)}
 			})
 		}
 	})
@@ -55,17 +76,17 @@ func (f *UReadability) extractPics(iselect *goquery.Selection, url string) (main
 	return mainImage, allImages, true
 }
 
-// getImageSize loads image to get size
-func (f *UReadability) getImageSize(url string) (size int) {
-	httpClient := &http.Client{Timeout: 30 * time.Second}
-	req, err := http.NewRequest("GET", url, http.NoBody)
+// getImageSize streams the image to measure its byte size without buffering it whole, honoring the
+// caller's context and capping the read at maxImageBytes.
+func (f *UReadability) getImageSize(ctx context.Context, url string) (size int) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		log.Printf("[WARN] can't create request to get pic from %s", url)
 		return 0
 	}
 	req.Close = true
 	req.Header.Set("User-Agent", userAgent)
-	resp, err := httpClient.Do(req)
+	resp, err := f.imageClient().Do(req)
 	if err != nil {
 		log.Printf("[WARN] can't get %s, error=%v", url, err)
 		return 0
@@ -76,10 +97,10 @@ func (f *UReadability) getImageSize(url string) (size int) {
 		}
 	}()
 
-	data, err := io.ReadAll(resp.Body)
+	n, err := io.Copy(io.Discard, io.LimitReader(resp.Body, maxImageBytes))
 	if err != nil {
 		log.Printf("[WARN] failed to get %s, err=%v", url, err)
 		return 0
 	}
-	return len(data)
+	return int(n)
 }

--- a/extractor/pics_test.go
+++ b/extractor/pics_test.go
@@ -49,7 +49,7 @@ func TestExtractPicsDirectly(t *testing.T) {
 		d, err := goquery.NewDocumentFromReader(strings.NewReader(data))
 		require.NoError(t, err)
 		sel := d.Find("img")
-		im, allImages, ok := lr.extractPics(sel, "url")
+		im, allImages, ok := lr.extractPics(context.Background(), sel, "url")
 		assert.True(t, ok)
 		assert.Len(t, allImages, 1)
 		assert.Equal(t, "https://cdn1.tnwcdn.com/wp-content/blogs.dir/1/files/2016/01/page-source.jpg", im)
@@ -60,7 +60,7 @@ func TestExtractPicsDirectly(t *testing.T) {
 		d, err := goquery.NewDocumentFromReader(strings.NewReader(data))
 		require.NoError(t, err)
 		sel := d.Find("img")
-		im, allImages, ok := lr.extractPics(sel, "url")
+		im, allImages, ok := lr.extractPics(context.Background(), sel, "url")
 		assert.False(t, ok)
 		assert.Empty(t, allImages)
 		assert.Empty(t, im)
@@ -71,10 +71,29 @@ func TestExtractPicsDirectly(t *testing.T) {
 		d, err := goquery.NewDocumentFromReader(strings.NewReader(data))
 		require.NoError(t, err)
 		sel := d.Find("img")
-		im, allImages, ok := lr.extractPics(sel, "url")
+		im, allImages, ok := lr.extractPics(context.Background(), sel, "url")
 		assert.True(t, ok)
 		assert.Len(t, allImages, 1)
 		assert.Equal(t, "http://bad_url", im)
+	})
+
+	t.Run("cancelled context returns zero size", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("some-image-bytes"))
+		}))
+		defer ts.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		assert.Equal(t, 0, lr.getImageSize(ctx, ts.URL))
+	})
+
+	t.Run("measures image size by streamed bytes", func(t *testing.T) {
+		payload := strings.Repeat("x", 1234)
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(payload))
+		}))
+		defer ts.Close()
+		assert.Equal(t, len(payload), lr.getImageSize(context.Background(), ts.URL))
 	})
 
 	t.Run("bad body of the image", func(t *testing.T) {
@@ -86,7 +105,7 @@ func TestExtractPicsDirectly(t *testing.T) {
 		d, err := goquery.NewDocumentFromReader(strings.NewReader(data))
 		require.NoError(t, err)
 		sel := d.Find("img")
-		im, allImages, ok := lr.extractPics(sel, "url")
+		im, allImages, ok := lr.extractPics(context.Background(), sel, "url")
 		assert.True(t, ok)
 		assert.Len(t, allImages, 1)
 		assert.Equal(t, ts.URL, im)

--- a/extractor/readability.go
+++ b/extractor/readability.go
@@ -4,6 +4,7 @@ package extractor
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
@@ -37,9 +38,15 @@ type UReadability struct {
 	Retriever   Retriever // default retriever; when nil a cached HTTPRetriever is used
 	CFRetriever Retriever // optional Cloudflare Browser Rendering retriever; when set, enables routing
 	CFRouteAll  bool      // route every request through CFRetriever (requires CFRetriever != nil)
+	// BlockPrivateNetworks rejects image fetches to non-public addresses. Guards image extraction
+	// against SSRF; set together with HTTPRetriever.BlockPrivateNetworks in public deployments.
+	BlockPrivateNetworks bool
 
 	defaultRetrieverOnce sync.Once
 	defaultRetriever     Retriever
+
+	imgClientOnce sync.Once
+	imgClient     *http.Client
 }
 
 // retriever returns the configured default Retriever, creating a cached HTTPRetriever if nil
@@ -153,7 +160,7 @@ func (f *UReadability) extractWithRules(ctx context.Context, reqURL string, rule
 		log.Printf("[WARN] failed to create document from reader, error=%v", err)
 		return nil, err
 	}
-	if im, allImages, ok := f.extractPics(darticle.Find("img"), reqURL); ok {
+	if im, allImages, ok := f.extractPics(ctx, darticle.Find("img"), reqURL); ok {
 		rb.Image = im
 		rb.AllImages = allImages
 	}

--- a/extractor/retriever.go
+++ b/extractor/retriever.go
@@ -32,6 +32,9 @@ type RetrieveResult struct {
 // HTTPRetriever fetches pages using a standard HTTP client
 type HTTPRetriever struct {
 	Timeout time.Duration
+	// BlockPrivateNetworks rejects fetches that resolve to loopback, private, link-local or other
+	// non-public addresses. Guards against SSRF via user-supplied URLs; enable in public deployments.
+	BlockPrivateNetworks bool
 
 	once   sync.Once
 	client *http.Client
@@ -46,6 +49,9 @@ func (h *HTTPRetriever) httpClient() *http.Client {
 			timeout = httpDefaultTimeout
 		}
 		h.client = &http.Client{Timeout: timeout}
+		if h.BlockPrivateNetworks {
+			h.client.Transport = safeTransport(timeout)
+		}
 	})
 	return h.client
 }

--- a/extractor/retriever_test.go
+++ b/extractor/retriever_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -77,6 +78,50 @@ func TestHTTPRetriever_Retrieve(t *testing.T) {
 			assert.Equal(t, tt.wantBody, string(result.Body))
 			assert.Equal(t, tt.wantURL, result.URL)
 			assert.NotNil(t, result.Header)
+		})
+	}
+}
+
+func TestHTTPRetriever_BlockPrivateNetworks(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("<html><body>internal</body></html>"))
+	}))
+	defer ts.Close()
+
+	t.Run("blocks loopback when enabled", func(t *testing.T) {
+		retriever := &HTTPRetriever{Timeout: 5 * time.Second, BlockPrivateNetworks: true}
+		result, err := retriever.Retrieve(context.Background(), ts.URL)
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, errBlockedAddress)
+	})
+
+	t.Run("allows loopback when disabled", func(t *testing.T) {
+		retriever := &HTTPRetriever{Timeout: 5 * time.Second}
+		result, err := retriever.Retrieve(context.Background(), ts.URL)
+		require.NoError(t, err)
+		assert.Equal(t, "<html><body>internal</body></html>", string(result.Body))
+	})
+}
+
+func TestIsBlockedIP(t *testing.T) {
+	tests := []struct {
+		ip      string
+		blocked bool
+	}{
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"10.0.0.1", true},
+		{"192.168.1.1", true},
+		{"172.16.0.1", true},
+		{"169.254.169.254", true}, // cloud metadata endpoint
+		{"0.0.0.0", true},
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ip, func(t *testing.T) {
+			assert.Equal(t, tt.blocked, isBlockedIP(net.ParseIP(tt.ip)))
 		})
 	}
 }

--- a/extractor/safedial.go
+++ b/extractor/safedial.go
@@ -1,0 +1,49 @@
+package extractor
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"syscall"
+	"time"
+)
+
+// errBlockedAddress is returned when a fetch targets a non-public address and private-network
+// blocking is enabled. the check runs at connect time against the actual resolved IP, so it also
+// defends against DNS rebinding and redirects that point back at internal hosts.
+var errBlockedAddress = errors.New("connection to non-public address blocked")
+
+// isBlockedIP reports whether ip is outside the public routable range and must not be dialed.
+func isBlockedIP(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast()
+}
+
+// safeControl is a net.Dialer Control hook that rejects connections to non-public addresses.
+func safeControl(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return err
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("%w: cannot parse address %q", errBlockedAddress, host)
+	}
+	if isBlockedIP(ip) {
+		return fmt.Errorf("%w: %s", errBlockedAddress, ip)
+	}
+	return nil
+}
+
+// safeTransport returns an http.Transport whose dialer blocks non-public addresses.
+func safeTransport(timeout time.Duration) *http.Transport {
+	dialer := &net.Dialer{Timeout: timeout, Control: safeControl}
+	tr, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return &http.Transport{DialContext: dialer.DialContext}
+	}
+	cloned := tr.Clone()
+	cloned.DialContext = dialer.DialContext
+	return cloned
+}

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 
 	// default retriever is always HTTP; CF is optional and, when configured, acts as a
 	// second retriever available for per-rule routing or global route-all.
-	httpRetriever := &extractor.HTTPRetriever{Timeout: 30 * time.Second}
+	httpRetriever := &extractor.HTTPRetriever{Timeout: 30 * time.Second, BlockPrivateNetworks: true}
 	var cfRetriever extractor.Retriever
 	if opts.CFAccountID != "" && opts.CFAPIToken != "" {
 		cfRetriever = &extractor.CloudflareRetriever{
@@ -79,12 +79,13 @@ func main() {
 
 	srv := rest.Server{
 		Readability: extractor.UReadability{
-			TimeOut:     30 * time.Second,
-			SnippetSize: 300,
-			Rules:       stores.Rules,
-			Retriever:   httpRetriever,
-			CFRetriever: cfRetriever,
-			CFRouteAll:  opts.CFRouteAll,
+			TimeOut:              30 * time.Second,
+			SnippetSize:          300,
+			Rules:                stores.Rules,
+			Retriever:            httpRetriever,
+			CFRetriever:          cfRetriever,
+			CFRouteAll:           opts.CFRouteAll,
+			BlockPrivateNetworks: true,
 		},
 		Token:       opts.Token,
 		Credentials: opts.Credentials,

--- a/rest/server.go
+++ b/rest/server.go
@@ -208,7 +208,7 @@ func (s *Server) handlePreview(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	testURLs := strings.Split(r.FormValue("test_urls"), "\n")
+	testURLs := splitTrimLines(r.FormValue("test_urls"))
 	content := strings.TrimSpace(r.FormValue("content"))
 	log.Printf("[INFO] test urls: %v", testURLs)
 	log.Printf("[INFO] custom rule: %v", content)
@@ -224,11 +224,6 @@ func (s *Server) handlePreview(w http.ResponseWriter, r *http.Request) {
 
 	responses := make([]extractor.Response, 0, len(testURLs))
 	for _, url := range testURLs {
-		url = strings.TrimSpace(url)
-		if url == "" {
-			continue
-		}
-
 		log.Printf("[DEBUG] custom rule provided for %s: %v", url, tempRule)
 		result, e := s.Readability.ExtractByRule(r.Context(), url, tempRule)
 		if e != nil {
@@ -286,9 +281,9 @@ func (s *Server) saveRule(w http.ResponseWriter, r *http.Request) {
 		Domain:        r.FormValue("domain"),
 		Author:        r.FormValue("author"),
 		Content:       r.FormValue("content"),
-		MatchURLs:     strings.Split(r.FormValue("match_url"), "\n"),
-		Excludes:      strings.Split(r.FormValue("excludes"), "\n"),
-		TestURLs:      strings.Split(r.FormValue("test_urls"), "\n"),
+		MatchURLs:     splitTrimLines(r.FormValue("match_url")),
+		Excludes:      splitTrimLines(r.FormValue("excludes")),
+		TestURLs:      splitTrimLines(r.FormValue("test_urls")),
 		UseCloudflare: r.FormValue("use_cloudflare") == "true",
 	}
 
@@ -342,6 +337,19 @@ func (s *Server) toggleRule(w http.ResponseWriter, r *http.Request) {
 func (s *Server) authFake(w http.ResponseWriter, _ *http.Request) {
 	t := time.Now()
 	rest.RenderJSON(w, JSON{"pong": t.Format("20060102150405")})
+}
+
+// splitTrimLines splits a textarea value into lines, trims surrounding whitespace (including the
+// \r that browsers send as part of \r\n line endings) and drops empty lines.
+func splitTrimLines(s string) []string {
+	raw := strings.Split(s, "\n")
+	out := make([]string, 0, len(raw))
+	for _, line := range raw {
+		if v := strings.TrimSpace(line); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 func getBid(id string) bson.ObjectID {

--- a/rest/server_test.go
+++ b/rest/server_test.go
@@ -534,6 +534,28 @@ func TestServer_SaveRule(t *testing.T) {
 	assert.Contains(t, string(body), "Failed to parse form")
 }
 
+func TestServer_SaveRuleTrimsLines(t *testing.T) {
+	ts, _ := startupT(t)
+	defer ts.Close()
+
+	domain := randStringBytesRmndr(42) + ".com"
+	// browsers submit textarea content with \r\n line endings and often a trailing blank line;
+	// %0D%0A is the url-encoded \r\n, %0A a bare \n
+	body := "domain=" + domain +
+		"&content=article" +
+		"&match_url=a.com%0D%0Ab.com%0D%0A%0D%0A" +
+		"&test_urls=http://x.com%0D%0A%0D%0Ahttp://y.com%0A"
+	resp, err := postFormUrlencoded(t, ts.URL+"/api/rule", body)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var rule datastore.Rule
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&rule))
+	assert.Equal(t, []string{"a.com", "b.com"}, rule.MatchURLs, "no \\r suffixes or empty entries")
+	assert.Equal(t, []string{"http://x.com", "http://y.com"}, rule.TestURLs)
+}
+
 func TestServer_Preview(t *testing.T) {
 	ts, _ := startupT(t)
 	defer ts.Close()


### PR DESCRIPTION
Fixes the three highest-priority issues from an end-to-end review of the current master.

## 1. SSRF via user-supplied URLs (security)

`POST /api/extract` is unauthenticated and the extractor fetched any URL it was given with no host validation, so a caller could reach `http://169.254.169.254/…` (cloud metadata), `localhost` and other internal hosts; image extraction (`getImageSize`) amplified it by following `<img src>` into more internal fetches.

Both the page retriever and the image fetcher now reject targets that resolve to loopback, private, link-local, unspecified or multicast addresses. The check runs in a `net.Dialer` `Control` hook against the actual IP at connect time, so it also covers redirect-to-internal and DNS rebinding. It is gated behind a new `BlockPrivateNetworks` flag, wired on in `main`; the default stays permissive so `httptest`-based tests (which bind loopback) keep working.

## 2. Textarea CRLF corruption on rule save (data integrity)

`saveRule` split `match_url`, `excludes` and `test_urls` on `"\n"` only. Browsers submit textareas with `\r\n`, so every stored entry kept a trailing `\r` and blank lines became empty-string entries, and this junk accumulated on every round-trip through the edit form. New `splitTrimLines` trims each line and drops empties; `handlePreview` reuses it in place of its ad-hoc split-and-trim loop.

## 3. Image sizing wasted resources on every extraction (efficiency)

`getImageSize` buffered each image fully into memory via `io.ReadAll`, built a fresh `http.Client` per image, ignored the request context, and spawned one unbounded goroutine per `<img>` on the page. It now streams to `io.Discard` behind a 10 MB `io.LimitReader`, shares a single client, propagates the caller's context, and caps concurrency at 8 probes per page.

## Tests

Added `TestHTTPRetriever_BlockPrivateNetworks`, `TestIsBlockedIP`, `TestServer_SaveRuleTrimsLines`, and two `getImageSize` subtests (context cancellation and streamed-byte measurement). Full suite passes with `-race`, `golangci-lint` and `go vet` clean.

## Note

SSRF blocking is opt-in (on in production via `main`, off by default) to avoid rewriting the loopback-based test suite. If you'd prefer it default-on with the tests adjusted to set an allow flag, that's an easy follow-up.