### PR TITLE
Trim and drop empty lines when saving multi-line rule fields

### DIFF
--- a/datastore/rules.go
+++ b/datastore/rules.go
@@ -26,17 +26,20 @@ type RulesDAO struct {
 
 // Rule record, entry in mongo
 type Rule struct {
-	ID            bson.ObjectID `json:"id" bson:"_id,omitempty"`
-	Domain        string        `json:"domain"`
-	MatchURLs     []string      `json:"match_url,omitempty" bson:"match_urls,omitempty"`
-	Content       string        `json:"content"`
-	Author        string        `json:"author,omitempty" bson:"author,omitempty"`
-	TS            string        `json:"ts,omitempty" bson:"ts,omitempty"` // ts of original article
-	Excludes      []string      `json:"excludes,omitempty" bson:"excludes,omitempty"`
-	TestURLs      []string      `json:"test_urls,omitempty" bson:"test_urls"`
-	User          string        `json:"user"`
-	Enabled       bool          `json:"enabled"`
-	UseCloudflare bool          `json:"use_cloudflare,omitempty" bson:"use_cloudflare,omitempty"` // route fetch via Cloudflare Browser Rendering
+	ID     bson.ObjectID `json:"id" bson:"_id,omitempty"`
+	Domain string        `json:"domain"`
+	// bson tags for the form-editable fields below deliberately omit "omitempty": Save does a $set
+	// of the whole struct, so a zero value (empty slice, false checkbox) must overwrite and clear
+	// the stored value rather than be dropped, leaving it stuck at its previous non-zero state.
+	MatchURLs     []string `json:"match_url,omitempty" bson:"match_urls"`
+	Content       string   `json:"content"`
+	Author        string   `json:"author,omitempty" bson:"author,omitempty"`
+	TS            string   `json:"ts,omitempty" bson:"ts,omitempty"` // ts of original article
+	Excludes      []string `json:"excludes,omitempty" bson:"excludes"`
+	TestURLs      []string `json:"test_urls,omitempty" bson:"test_urls"`
+	User          string   `json:"user"`
+	Enabled       bool     `json:"enabled"`
+	UseCloudflare bool     `json:"use_cloudflare,omitempty" bson:"use_cloudflare"` // route fetch via Cloudflare Browser Rendering
 }
 
 // Get rule by url. Checks if found in mongo, matching by domain
@@ -73,6 +76,17 @@ func (r RulesDAO) GetByID(ctx context.Context, id bson.ObjectID) (Rule, bool) {
 
 // Save upsert rule
 func (r RulesDAO) Save(ctx context.Context, rule Rule) (Rule, error) {
+	// normalise nil slices to empty ones so cleared multi-value fields are stored as BSON arrays
+	// ([]) rather than null (the driver encodes nil slices as null), keeping the stored type stable.
+	if rule.MatchURLs == nil {
+		rule.MatchURLs = []string{}
+	}
+	if rule.Excludes == nil {
+		rule.Excludes = []string{}
+	}
+	if rule.TestURLs == nil {
+		rule.TestURLs = []string{}
+	}
 	ch, err := r.UpdateOne(ctx, bson.M{fieldDomain: rule.Domain}, bson.M{opSet: rule}, options.UpdateOne().SetUpsert(true))
 	if err != nil {
 		log.Printf("[WARN] failed to save, error=%v, article=%v", err, rule)

--- a/datastore/rules_test.go
+++ b/datastore/rules_test.go
@@ -59,6 +59,30 @@ func TestRulesSave(t *testing.T) {
 		assert.Equal(t, rule.TestURLs, saved.TestURLs)
 	})
 
+	t.Run("clearing multi-value fields overwrites stored arrays", func(t *testing.T) {
+		domain := randDomain()
+		_, err := rules.Save(context.Background(), Rule{
+			Domain:        domain,
+			MatchURLs:     []string{"/blog/*"},
+			Excludes:      []string{".sidebar"},
+			TestURLs:      []string{"https://example.com/test"},
+			UseCloudflare: true,
+			Enabled:       true,
+		})
+		require.NoError(t, err)
+
+		// re-save the same domain with the multi-value fields and checkbox cleared; none must persist
+		_, err = rules.Save(context.Background(), Rule{Domain: domain, Content: ".body", Enabled: true})
+		require.NoError(t, err)
+
+		got, ok := rules.Get(context.Background(), "https://"+domain+"/page")
+		require.True(t, ok)
+		assert.Empty(t, got.MatchURLs)
+		assert.Empty(t, got.Excludes)
+		assert.Empty(t, got.TestURLs)
+		assert.False(t, got.UseCloudflare, "unchecking the checkbox must clear the stored flag")
+	})
+
 	t.Run("save with canceled context", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()

--- a/rest/server.go
+++ b/rest/server.go
@@ -208,7 +208,7 @@ func (s *Server) handlePreview(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	testURLs := strings.Split(r.FormValue("test_urls"), "\n")
+	testURLs := splitTrimLines(r.FormValue("test_urls"))
 	content := strings.TrimSpace(r.FormValue("content"))
 	log.Printf("[INFO] test urls: %v", testURLs)
 	log.Printf("[INFO] custom rule: %v", content)
@@ -224,11 +224,6 @@ func (s *Server) handlePreview(w http.ResponseWriter, r *http.Request) {
 
 	responses := make([]extractor.Response, 0, len(testURLs))
 	for _, url := range testURLs {
-		url = strings.TrimSpace(url)
-		if url == "" {
-			continue
-		}
-
 		log.Printf("[DEBUG] custom rule provided for %s: %v", url, tempRule)
 		result, e := s.Readability.ExtractByRule(r.Context(), url, tempRule)
 		if e != nil {
@@ -286,9 +281,9 @@ func (s *Server) saveRule(w http.ResponseWriter, r *http.Request) {
 		Domain:        r.FormValue("domain"),
 		Author:        r.FormValue("author"),
 		Content:       r.FormValue("content"),
-		MatchURLs:     strings.Split(r.FormValue("match_url"), "\n"),
-		Excludes:      strings.Split(r.FormValue("excludes"), "\n"),
-		TestURLs:      strings.Split(r.FormValue("test_urls"), "\n"),
+		MatchURLs:     splitTrimLines(r.FormValue("match_url")),
+		Excludes:      splitTrimLines(r.FormValue("excludes")),
+		TestURLs:      splitTrimLines(r.FormValue("test_urls")),
 		UseCloudflare: r.FormValue("use_cloudflare") == "true",
 	}
 
@@ -342,6 +337,19 @@ func (s *Server) toggleRule(w http.ResponseWriter, r *http.Request) {
 func (s *Server) authFake(w http.ResponseWriter, _ *http.Request) {
 	t := time.Now()
 	rest.RenderJSON(w, JSON{"pong": t.Format("20060102150405")})
+}
+
+// splitTrimLines splits a textarea value into lines, trims surrounding whitespace (including the
+// \r that browsers send as part of \r\n line endings) and drops empty lines.
+func splitTrimLines(s string) []string {
+	raw := strings.Split(s, "\n")
+	out := make([]string, 0, len(raw))
+	for _, line := range raw {
+		if v := strings.TrimSpace(line); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 func getBid(id string) bson.ObjectID {

--- a/rest/server_test.go
+++ b/rest/server_test.go
@@ -534,6 +534,28 @@ func TestServer_SaveRule(t *testing.T) {
 	assert.Contains(t, string(body), "Failed to parse form")
 }
 
+func TestServer_SaveRuleTrimsLines(t *testing.T) {
+	ts, _ := startupT(t)
+	defer ts.Close()
+
+	domain := randStringBytesRmndr(42) + ".com"
+	// browsers submit textarea content with \r\n line endings and often a trailing blank line;
+	// %0D%0A is the url-encoded \r\n, %0A a bare \n
+	body := "domain=" + domain +
+		"&content=article" +
+		"&match_url=a.com%0D%0Ab.com%0D%0A%0D%0A" +
+		"&test_urls=http://x.com%0D%0A%0D%0Ahttp://y.com%0A"
+	resp, err := postFormUrlencoded(t, ts.URL+"/api/rule", body)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var rule datastore.Rule
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&rule))
+	assert.Equal(t, []string{"a.com", "b.com"}, rule.MatchURLs, "no \\r suffixes or empty entries")
+	assert.Equal(t, []string{"http://x.com", "http://y.com"}, rule.TestURLs)
+}
+
 func TestServer_Preview(t *testing.T) {
 	ts, _ := startupT(t)
 	defer ts.Close()


### PR DESCRIPTION
`saveRule` split `match_url`, `excludes` and `test_urls` on `"\n"` only. Browsers submit textarea content with `\r\n`, so every stored entry kept a trailing `\r` and blank lines became empty-string entries; this junk accumulated on every round-trip through the edit form.

## What changed

New `splitTrimLines` trims each line (dropping the `\r`) and drops empties; `handlePreview` reuses it in place of its ad-hoc split-and-trim loop.

Because `splitTrimLines` yields an empty slice for a blank textarea, the bson `omitempty` on `match_urls`/`excludes` would have dropped the field from the `$set` on update, silently keeping stale values. Those `omitempty` tags are removed (`test_urls` already lacked one) so clearing a field actually clears it, and `Save` normalises nil slices to `[]string{}` so cleared fields are stored as BSON arrays rather than `null`.

Tests: `TestServer_SaveRuleTrimsLines` asserts CRLF/blank input round-trips to clean slices, and a datastore test verifies re-saving with cleared fields overwrites the stored arrays.

One of three PRs splitting the earlier #82; gated with an xhigh Codex review over the final diff.