### PR TITLE
Cache Docker build layers with type=gha

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,6 +60,8 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=max,ignore-error=true
           build-args: |
             CI=github
             GITHUB_SHA=${{ github.event.workflow_run.head_sha }}
@@ -73,6 +75,8 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
+          # reuse the layers the ghcr build just cached so this is a cache hit, not a full rebuild
+          cache-from: type=gha,scope=${{ matrix.platform }}
           build-args: |
             CI=github
             GITHUB_SHA=${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
The `docker.yml` build used no build cache, so every run rebuilt both images from scratch. Add buildx `type=gha` cache scoped per platform.

The GHCR build (required) populates the cache (`cache-to`, `mode=max`); the optional DockerHub build reuses those layers via `cache-from`, so it becomes a cache hit rather than a second full rebuild — while keeping its `continue-on-error` best-effort semantics. `cache-to` carries `ignore-error=true` so a GitHub cache-service hiccup during cache export can't fail the required publish (cache is only an optimisation).